### PR TITLE
Switched order of environment loading and system merging 

### DIFF
--- a/CORE/world_gadgets/configuration_engine.rb
+++ b/CORE/world_gadgets/configuration_engine.rb
@@ -4,8 +4,8 @@ class ConfigurationEngine
 
   def initialize
     @config_data = JSON.parse(File.read("#{ENV['OZ_CONFIG_DIR']}/user_config.json"))
-    load_environment
     merge_system_config
+    load_environment
   end
 
   def load_environment


### PR DESCRIPTION
Switched order of environment loading and system merging so that environment can be set at the command line. fixes #46 