### PR TITLE
Adding configuration option 'HEADLESS_CHROME'

### DIFF
--- a/CORE/world_gadgets/browser_engine.rb
+++ b/CORE/world_gadgets/browser_engine.rb
@@ -22,18 +22,20 @@ class BrowserEngine
   end
 
   def chrome_browser
-    caps = Selenium::WebDriver::Remote::Capabilities.chrome(chrome_options: {'detach' => true})
-
     if @world.configuration['USE_GRID']
-      driver = Selenium::WebDriver.for(:remote, :url => @world.configuration['ENVIRONMENT']['GRID'] , desired_capabilities: caps)
+      capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chrome_options: {'detach' => true})
+      driver = Selenium::WebDriver.for(:remote, :url => @world.configuration['ENVIRONMENT']['GRID'] , desired_capabilities: capabilities)
     else
+      options = Selenium::WebDriver::Chrome::Options.new
+      options.add_argument('headless') if @world.configuration['HEADLESS_CHROME']
+
       if OS.linux?
         path = "#{@world.configuration['CORE_DIR']}/utils/web_drivers/linux-chromedriver"
       else
         path = "#{@world.configuration['CORE_DIR']}/utils/web_drivers/chromedriver"
         path += '.exe' if OS.windows?
       end      
-      driver = Selenium::WebDriver.for(:chrome, desired_capabilities: caps, driver_path: path)
+      driver = Selenium::WebDriver.for(:chrome, options: options, driver_path: path)
     end
     return Watir::Browser.new(driver)
   end

--- a/EXAMPLE/config/user_config.json
+++ b/EXAMPLE/config/user_config.json
@@ -3,6 +3,7 @@
   "LOG_LEVEL":"ACTION",
   "BROWSER":"chrome",
   "CREATE_DOT_GRAPH":true,
-  "CLOSE_BROWSER":false,
-  "PRINT_LEDGER":true
+  "CLOSE_BROWSER":true,
+  "PRINT_LEDGER":true,
+  "HEADLESS_CHROME":false
 }


### PR DESCRIPTION
Addressses #60 

Currently splitting out driver generation for chrome depending on `USE_GRID` value. However, I am unsure if we _want_ grid to work in headless mode anyway. If we do, that will most likely be another issue.