### PR TITLE
Fixing Deprecations

### DIFF
--- a/CORE/world_extensions/core_world.rb
+++ b/CORE/world_extensions/core_world.rb
@@ -1,5 +1,4 @@
-
-require 'watir-webdriver'
+require 'watir'
 
 module CoreWorld
 

--- a/EXAMPLE/pages/01_catalog_pages/casual_dresses_page.rb
+++ b/EXAMPLE/pages/01_catalog_pages/casual_dresses_page.rb
@@ -2,11 +2,11 @@
 
 class CasualDressesPage < ExampleStorefrontBasePage
 
-  add_id_element(:h1, /CASUAL DRESSES/, class: 'page-heading product-listing')
+  add_id_element(:h1, /CASUAL DRESSES/, class: ['page-heading', 'product-listing'])
 
   def create_elements
 
-    add_static_text(:title, element_type: :h1, class: 'page-heading product-listing')
+    add_static_text(:title, element_type: :h1, class: ['page-heading', 'product-listing'])
   end
 
 end

--- a/EXAMPLE/pages/01_catalog_pages/dresses_page.rb
+++ b/EXAMPLE/pages/01_catalog_pages/dresses_page.rb
@@ -2,14 +2,14 @@
 
 class DressesPage < ExampleStorefrontBasePage
 
-  add_id_element(:h1, /DRESSES \nThere are 5 products./, class: 'page-heading product-listing')
+  add_id_element(:h1, /DRESSES \nThere are 5 products./, class: ['page-heading', 'product-listing'])
   add_route(:CasualDressesPage, :casual_dresses_button)
 
   def create_elements
 
     add_button(:casual_dresses, element_type: :link, xpath: "//div[@id='categories_block_left']/div/ul/li[1]/a")
 
-    add_static_text(:title, element_type: :h1, class: 'page-heading product-listing')
+    add_static_text(:title, element_type: :h1, class: ['page-heading', 'product-listing'])
 
   end
 


### PR DESCRIPTION
I noticed that there were a few deprecations for Watir.

1. Watir was being required via `require 'watir-webdriver'` instead of `require 'watir'`
2. The Example application was using strings instead of arrays of strings for elements with multiple classes.