### PR TITLE
Implement 'default' terminal color in logs

### DIFF
--- a/CORE/utils/class_extensions.rb
+++ b/CORE/utils/class_extensions.rb
@@ -1,34 +1,33 @@
-
 class Symbol
-    def + (second_sym)
-        raise ArgumentError unless second_sym.class == Symbol
-        return "#{self}_#{second_sym}".to_sym
-    end
+  def + (second_sym)
+    raise ArgumentError unless second_sym.class == Symbol
+    return "#{self}_#{second_sym}".to_sym
+  end
 end
 
 class String
-	def black;          "\e[30m#{self}\e[0m" end
-	def red;            "\e[31m#{self}\e[0m" end
-	def green;          "\e[32m#{self}\e[0m" end
-	def orange;         "\e[33m#{self}\e[0m" end
-	def blue;           "\e[34m#{self}\e[0m" end
-	def pink;           "\e[35m#{self}\e[0m" end
-	def cyan;           "\e[36m#{self}\e[0m" end
-	def gray;           "\e[37m#{self}\e[0m" end
+  def black;          "\e[30m#{self}\e[0m" end
+  def red;            "\e[31m#{self}\e[0m" end
+  def green;          "\e[32m#{self}\e[0m" end
+  def orange;         "\e[33m#{self}\e[0m" end
+  def blue;           "\e[34m#{self}\e[0m" end
+  def pink;           "\e[35m#{self}\e[0m" end
+  def cyan;           "\e[36m#{self}\e[0m" end
+  def gray;           "\e[37m#{self}\e[0m" end
   def default;        self                 end
 
-	def bg_black;       "\e[40m#{self}\e[0m" end
-	def bg_red;         "\e[41m#{self}\e[0m" end
-	def bg_green;       "\e[42m#{self}\e[0m" end
-	def bg_orange;      "\e[43m#{self}\e[0m" end
-	def bg_blue;        "\e[44m#{self}\e[0m" end
-	def bg_pink;        "\e[45m#{self}\e[0m" end
-	def bg_cyan;        "\e[46m#{self}\e[0m" end
-	def bg_gray;        "\e[47m#{self}\e[0m" end
+  def bg_black;       "\e[40m#{self}\e[0m" end
+  def bg_red;         "\e[41m#{self}\e[0m" end
+  def bg_green;       "\e[42m#{self}\e[0m" end
+  def bg_orange;      "\e[43m#{self}\e[0m" end
+  def bg_blue;        "\e[44m#{self}\e[0m" end
+  def bg_pink;        "\e[45m#{self}\e[0m" end
+  def bg_cyan;        "\e[46m#{self}\e[0m" end
+  def bg_gray;        "\e[47m#{self}\e[0m" end
   def bg_default;     self                 end
 
-	def bold;           "\e[1m#{self}\e[22m" end
-	def italic;         "\e[3m#{self}\e[23m" end
-	def underline;      "\e[4m#{self}\e[24m" end
-	def blink;          "\e[5m#{self}\e[25m" end
+  def bold;           "\e[1m#{self}\e[22m" end
+  def italic;         "\e[3m#{self}\e[23m" end
+  def underline;      "\e[4m#{self}\e[24m" end
+  def blink;          "\e[5m#{self}\e[25m" end
 end

--- a/CORE/utils/class_extensions.rb
+++ b/CORE/utils/class_extensions.rb
@@ -15,6 +15,7 @@ class String
 	def pink;           "\e[35m#{self}\e[0m" end
 	def cyan;           "\e[36m#{self}\e[0m" end
 	def gray;           "\e[37m#{self}\e[0m" end
+  def default;        self                 end
 
 	def bg_black;       "\e[40m#{self}\e[0m" end
 	def bg_red;         "\e[41m#{self}\e[0m" end
@@ -24,6 +25,7 @@ class String
 	def bg_pink;        "\e[45m#{self}\e[0m" end
 	def bg_cyan;        "\e[46m#{self}\e[0m" end
 	def bg_gray;        "\e[47m#{self}\e[0m" end
+  def bg_default;     self                 end
 
 	def bold;           "\e[1m#{self}\e[22m" end
 	def italic;         "\e[3m#{self}\e[23m" end

--- a/CORE/world_gadgets/oz_logger.rb
+++ b/CORE/world_gadgets/oz_logger.rb
@@ -17,7 +17,7 @@ class OzLogger
   def debug(message)
     prefix = '[ DEBUG    ]-> '
     prefix = prefix.gray unless @colorless
-    puts prefix + "#{_color_escape(message, :gray, :black)}" if @debug_level <= self.class.DEBUG
+    puts prefix + "#{_color_escape(message, :default, :orange)}" if @debug_level <= self.class.DEBUG
   end
 
   def header(message)
@@ -27,13 +27,13 @@ class OzLogger
   def action(message)
     prefix = '[ ACTION   ]-> '
     prefix = prefix.cyan unless @colorless
-    puts prefix + "#{_color_escape(message, :black, :cyan)}" if @debug_level <= self.class.ACTION
+    puts prefix + "#{_color_escape(message, :default, :cyan)}" if @debug_level <= self.class.ACTION
   end
 
   def validation(message)
     prefix = '[ VALIDATE ]-> '
     prefix = prefix.green unless @colorless
-    puts prefix + "#{_color_escape(message, :black, :green)}" if @debug_level <= self.class.ACTION
+    puts prefix + "#{_color_escape(message, :default, :green)}" if @debug_level <= self.class.ACTION
   end
 
   def warn(message)

--- a/CORE/world_gadgets/oz_logger.rb
+++ b/CORE/world_gadgets/oz_logger.rb
@@ -17,7 +17,7 @@ class OzLogger
   def debug(message)
     prefix = '[ DEBUG    ]-> '
     prefix = prefix.gray unless @colorless
-    puts prefix + "#{_color_escape(message, :default, :orange)}" if @debug_level <= self.class.DEBUG
+    puts prefix + "#{_color_escape(message, :gray, :default)}" if @debug_level <= self.class.DEBUG
   end
 
   def header(message)

--- a/CORE/world_gadgets/oz_logger.rb
+++ b/CORE/world_gadgets/oz_logger.rb
@@ -1,5 +1,3 @@
-
-
 class OzLogger
   # We can't just name this class 'Logger' because Cucumber has a class named that already :(
 
@@ -60,5 +58,4 @@ class OzLogger
     end
     return message
   end
-
 end


### PR DESCRIPTION
Adding a default terminal font color class extension for the string class. This allows messages to specify the default terminal font color inside of the Oz Logger.

Previously, we were hard-coding certain messages as `black`, which caused an unsatisfactory output for users with dark-colored terminal themes.

Further investigation/development is needed for user-defined themes. However, this should be a good intermediary step allowing for both light and dark themed terminals to display the messages in their intended color priority.

