### PR TITLE
Adding clear flag to allow a manual clear on a per element basis

### DIFF
--- a/CORE/elements/_core_element.rb
+++ b/CORE/elements/_core_element.rb
@@ -34,6 +34,7 @@ class CoreElement
     @world = world
     @options = {:active => true}.merge(options)
     @active = @options[:active]
+    @clear = @options[:clear] ? true : false
 
     assign_element_type
   end

--- a/CORE/elements/text_field.rb
+++ b/CORE/elements/text_field.rb
@@ -19,7 +19,7 @@ class TextFieldElement < CoreElement
     def fill(data)
       assert_active
       @world.logger.action "Filling [#{@name}] with [#{data}]"
-      manually_clear if @world.configuration["BROWSER"] == "internet_explorer"
+      manually_clear if @world.configuration["BROWSER"] == "internet_explorer" || @clear
       watir_element.set(data)
 
       begin


### PR DESCRIPTION
During use in our AUT, we've found that Oz can get a bit finicky on filling certain fields if the field already had a value. We added in the `@clear` flag to allow us to set particular elements to manually clear no matter which browser they're in.

I feel this would be a good candidate for CORE, as it's a behavior I've seen while testing other applications as well.