### PR TITLE
handle ruby namespacing

### DIFF
--- a/CORE/utils/core_utils.rb
+++ b/CORE/utils/core_utils.rb
@@ -3,7 +3,7 @@ module CoreUtils
 
   def self.find_class(name)
     if name.class == String
-      name = name.gsub(/::(\w)| (\w)/, &:upcase).tr(' ','')
+      name = name.gsub(/::(\w)| (\w)/, {|match| match.upcase}).tr(' ','')
     end
     return Kernel.const_get(name)
   end

--- a/CORE/utils/core_utils.rb
+++ b/CORE/utils/core_utils.rb
@@ -3,7 +3,7 @@ module CoreUtils
 
   def self.find_class(name)
     if name.class == String
-      name = name.gsub(/::(\w)| (\w)/, {|match| match.upcase}).tr(' ','')
+      name = name.gsub(/::(\w)| (\w)/, {|match| match.upcase}).gsub(' ','')
     end
     return Kernel.const_get(name)
   end

--- a/CORE/utils/core_utils.rb
+++ b/CORE/utils/core_utils.rb
@@ -3,7 +3,7 @@ module CoreUtils
 
   def self.find_class(name)
     if name.class == String
-      name = name.split(" ").map{|word| word.strip.capitalize}.join('')
+      name = name.gsub(/::(\w)| (\w)/, &:upcase).tr(' ','')
     end
     return Kernel.const_get(name)
   end

--- a/CORE/utils/core_utils.rb
+++ b/CORE/utils/core_utils.rb
@@ -3,7 +3,7 @@ module CoreUtils
 
   def self.find_class(name)
     if name.class == String
-      name = name.gsub(/::(\w)| (\w)/, {|match| match.upcase}).gsub(' ','')
+      name = name.gsub(/::(\w)| (\w)/){|match| match.upcase.delete(' ')}
     end
     return Kernel.const_get(name)
   end


### PR DESCRIPTION
oz currently does not gracefully handle pages that have been namespaced.  This is a proposed fix to that

Use Case:

```ruby
#!~ public_site.rb
module PublicSite
end

#!~ public_site/home_page.rb
module PublicSite
  class HomePage < BasePage
  end
end
```

This allows for pages to be organized into packages and keeps the name space a lot cleaner.