### PR TITLE
Add the ability to pass arguments in routes

### DIFF
--- a/CORE/pages/core_page.rb
+++ b/CORE/pages/core_page.rb
@@ -36,6 +36,10 @@ class CorePage
         @elements[element_name].click
     end
 
+    def wait_for(element_name, timeout: 3)
+        CoreUtils.wait_until(timeout) { @elements[element_name].present? }
+    end
+
     def hover_over(element_name)
       @elements[element_name].hover
     end

--- a/CORE/pages/core_page.rb
+++ b/CORE/pages/core_page.rb
@@ -40,6 +40,14 @@ class CorePage
       @elements[element_name].hover
     end
 
+    def activate(element_name)
+        @elements[element_name].activate
+    end
+
+    def deactivate(element_name)
+        @elements[element_name].deactivate
+    end
+
     def validate_content
         data = expected_data()
         raise ArgumentError, "ERROR: Method: [expected_data] of class [#{self.class}] should return a Hash\n" unless data.class == Hash

--- a/CORE/pages/core_page.rb
+++ b/CORE/pages/core_page.rb
@@ -36,20 +36,8 @@ class CorePage
         @elements[element_name].click
     end
 
-    def wait_for(element_name, timeout: 3)
-        CoreUtils.wait_until(timeout) { @elements[element_name].present? }
-    end
-
     def hover_over(element_name)
       @elements[element_name].hover
-    end
-
-    def activate(element_name)
-        @elements[element_name].activate
-    end
-
-    def deactivate(element_name)
-        @elements[element_name].deactivate
     end
 
     def validate_content

--- a/CORE/world_gadgets/router/core_page_navigation.rb
+++ b/CORE/world_gadgets/router/core_page_navigation.rb
@@ -28,9 +28,16 @@ class CorePage
 
 
     def navigate_via_route(route)
-        route.prerequisites.each { |prerequisite| self.send(prerequisite) }
+        route.prerequisites.each do |prerequisite|
+            self.send(prerequisite) unless prerequisite.is_a? Array
+            self.send(prerequisite[0], prerequisite[1]) if prerequisite.is_a? Array
+        end
         action = route.action
-        self.respond_to?(action) ? self.send(action) : @elements[action].click
+        if action.is_a? Array
+            self.send(action[0], *action[1..-1])
+        else
+            self.respond_to?(action) ? self.send(action) : @elements[action].click
+        end
         @world.assert_and_set_page(route.target_page)
     end
 

--- a/CORE/world_gadgets/router/page_blueprint.rb
+++ b/CORE/world_gadgets/router/page_blueprint.rb
@@ -24,7 +24,8 @@ class PageBlueprint
   end
 
   def add_route(target_page, action, prerequisites)
-    @routes[target_page] ||= Route.new( target_page, action, [ prerequisites ].flatten )
+    prerequisites = [prerequisites] unless prerequisites.is_a? Array
+    @routes[target_page] ||= Route.new( target_page, action, prerequisites )
   end
 
   def add_id_element(element, action)

--- a/EXAMPLE/pages/home_page.rb
+++ b/EXAMPLE/pages/home_page.rb
@@ -27,11 +27,12 @@ class HomePage < ExampleStorefrontRootPage
   end
 
   def navigate_to(menu, sub_section)
+    sub_section_link = @elements[:"#{sub_section}_button"]
     hover_over :"#{menu}_button"
-    wait_for :"#{sub_section}_button"
-    activate :"#{sub_section}_button"
-    click_on :"#{sub_section}_button"
-    deactivate :"#{sub_section}_button"
+    CoreUtils.wait_until(3) {element.present?}
+    sub_section_link.activate
+    sub_section_link.click
+    sub_section_link.deactivate
   end
 
 end

--- a/EXAMPLE/pages/home_page.rb
+++ b/EXAMPLE/pages/home_page.rb
@@ -11,13 +11,19 @@ class HomePage < ExampleStorefrontRootPage
 
     @dresses_button = add_button(:dresses, element_type: :link, xpath: "//div[@id='block_top_menu']/ul/li[2]/a")
 
-    @casual_dresses_button = add_button(:casual_dresses, element_type: :link, xpath: "//div[@id='block_top_menu']/ul/li[2]/ul/li[1]/a")
-    @casual_dresses_button.deactivate
+    @casual_dresses_button = add_button(:casual_dresses, active: false, element_type: :link, xpath: "//div[@id='block_top_menu']/ul/li[2]/ul/li[1]/a")
 
     add_static_text(:phone_info, element_type: :span, class: 'shop-phone')
     add_static_text(:practice_header, element_type: :h1, xpath: "//div[@id='editorial_block_center']/h1")
     add_static_text(:sub_header, element_type: :h2, xpath: "//div[@id='editorial_block_center']/h2")
+    assign_element_logic
+  end
 
+  def assign_element_logic
+    @dresses_button.on_hover do
+      @casual_dresses_button.activate
+      CoreUtils.wait_until(3) { @casual_dresses_button.present? }
+    end
   end
 
   def navigate_to(menu, sub_section)
@@ -26,11 +32,6 @@ class HomePage < ExampleStorefrontRootPage
     activate :"#{sub_section}_button"
     click_on :"#{sub_section}_button"
     deactivate :"#{sub_section}_button"
-  end
-
-  def navigate_to_casual_via_hover
-    @dresses_button.hover
-    @casual_dresses_button.click
   end
 
 end

--- a/EXAMPLE/pages/home_page.rb
+++ b/EXAMPLE/pages/home_page.rb
@@ -5,7 +5,7 @@ class HomePage < ExampleStorefrontRootPage
   add_id_element(:div, /Automation Practice Website/, id: 'editorial_block_center')
   add_route(:DressesPage, :dresses_button)
   add_route(:SignInPage, :sign_in_button)
-  add_route(:CasualDressesPage, :navigate_to_casual_via_hover)
+  add_route(:CasualDressesPage, [:navigate_to, :dresses, :casual_dresses])
 
   def create_elements
 
@@ -14,15 +14,18 @@ class HomePage < ExampleStorefrontRootPage
     @casual_dresses_button = add_button(:casual_dresses, element_type: :link, xpath: "//div[@id='block_top_menu']/ul/li[2]/ul/li[1]/a")
     @casual_dresses_button.deactivate
 
-    @dresses_button.on_hover do
-      @casual_dresses_button.activate
-      CoreUtils.wait_until(3) { @casual_dresses_button.present? }
-    end
-
     add_static_text(:phone_info, element_type: :span, class: 'shop-phone')
     add_static_text(:practice_header, element_type: :h1, xpath: "//div[@id='editorial_block_center']/h1")
     add_static_text(:sub_header, element_type: :h2, xpath: "//div[@id='editorial_block_center']/h2")
 
+  end
+
+  def navigate_to(menu, sub_section)
+    hover_over :"#{menu}_button"
+    wait_for :"#{sub_section}_button"
+    activate :"#{sub_section}_button"
+    click_on :"#{sub_section}_button"
+    deactivate :"#{sub_section}_button"
   end
 
   def navigate_to_casual_via_hover


### PR DESCRIPTION
After talking to @PanoramicPanda, i came to the conclusion that this functionality might be useful in OzCore

The idea is that you can pass arguments to a route on a page in the form of:
```ruby
add_route(:CasualDressesPage, [:navigate_to, :dresses, :casual_dresses])
  
def navigate_to(menu, sub_section)
  sub_section_link = @elements[:"#{sub_section}_button"]
  CoreUtils.wait_until(3) {element.present?}
  sub_section_link.activate
  sub_section_link.click
  sub_section_link.deactivate
end
```
FROM: https://github.com/OzFramework/oz/commit/13d5d4f6fe6f04ce275c08acacb70d5652f7b139#diff-b6489fb70c3ad0e2bed6438f4550b728R8

Instead of
```ruby
...
def create_elements
  @dresses_button.on_hover do
    @casual_dresses_button.activate
    CoreUtils.wait_until(3) { @casual_dresses_button.present? }
  end
end
...
def navigate_to_casual_via_hover
  @dresses_button.hover
  @casual_dresses_button.click
end

```

The logic behind this change is that it allows replication to be reduced rather drastically on pages where we have a large quantity of something that is interacted with an a very common way, like a header menu. (Like the dresses menu in example)  In the current codebase we have to define each and every route as a method (we cannot :fill a link) which leads to rather lengthy page objects.

This implementation should not break existing implementations that are using inbuilt core functionality (Example does not seem to break from this)